### PR TITLE
Add meter_event_name storage for metered items

### DIFF
--- a/database/factories/SubscriptionItemFactory.php
+++ b/database/factories/SubscriptionItemFactory.php
@@ -29,6 +29,7 @@ class SubscriptionItemFactory extends Factory
             'stripe_product' => 'prod_'.Str::random(40),
             'stripe_price' => 'price_'.Str::random(40),
             'quantity' => null,
+            'meter_event_name' => null,
         ];
     }
 }

--- a/database/migrations/2024_06_06_000004_add_meter_event_name_to_subscription_items_table.php
+++ b/database/migrations/2024_06_06_000004_add_meter_event_name_to_subscription_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subscription_items', function (Blueprint $table) {
+            $table->string('meter_event_name')->nullable()->after('quantity');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subscription_items', function (Blueprint $table) {
+            $table->dropColumn('meter_event_name');
+        });
+    }
+};

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -734,12 +734,20 @@ class Subscription extends Model
         foreach ($stripeSubscription->items as $item) {
             $subscriptionItemIds[] = $item->id;
 
+            $meterEventName = null;
+
+            if (isset($item->price->recurring->meter)) {
+                $meter = $this->owner->stripe()->billing->meters->retrieve($item->price->recurring->meter);
+                $meterEventName = $meter->event_name;
+            }
+
             $this->items()->updateOrCreate([
                 'stripe_id' => $item->id,
             ], [
                 'stripe_product' => $item->price->product,
                 'stripe_price' => $item->price->id,
                 'quantity' => $item->quantity ?? null,
+                'meter_event_name' => $meterEventName,
             ]);
         }
 
@@ -887,6 +895,15 @@ class Subscription extends Model
             throw SubscriptionUpdateFailure::duplicatePrice($this, $price);
         }
 
+        $stripePrice = $this->owner->stripe()->prices->retrieve($price);
+
+        $meterEventName = null;
+
+        if (isset($stripePrice->recurring->meter)) {
+            $meter = $this->owner->stripe()->billing->meters->retrieve($stripePrice->recurring->meter);
+            $meterEventName = $meter->event_name;
+        }
+
         $stripeSubscriptionItem = $this->owner->stripe()->subscriptionItems
             ->create(array_filter(array_merge([
                 'subscription' => $this->stripe_id,
@@ -902,6 +919,7 @@ class Subscription extends Model
             'stripe_product' => $stripeSubscriptionItem->price->product,
             'stripe_price' => $stripeSubscriptionItem->price->id,
             'quantity' => $stripeSubscriptionItem->quantity ?? null,
+            'meter_event_name' => $meterEventName,
         ]);
 
         $this->unsetRelation('items');

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -36,6 +36,7 @@ class SubscriptionItem extends Model
      */
     protected $casts = [
         'quantity' => 'integer',
+        'meter_event_name' => 'string',
     ];
 
     /**
@@ -150,6 +151,15 @@ class SubscriptionItem extends Model
     {
         $this->subscription->guardAgainstIncomplete();
 
+        $stripePrice = $this->subscription->owner->stripe()->prices->retrieve($price);
+
+        $meterEventName = null;
+
+        if (isset($stripePrice->recurring->meter)) {
+            $meter = $this->subscription->owner->stripe()->billing->meters->retrieve($stripePrice->recurring->meter);
+            $meterEventName = $meter->event_name;
+        }
+
         $stripeSubscriptionItem = $this->updateStripeSubscriptionItem(array_merge(
             array_filter([
                 'price' => $price,
@@ -166,6 +176,7 @@ class SubscriptionItem extends Model
             'stripe_product' => $stripeSubscriptionItem->price->product,
             'stripe_price' => $stripeSubscriptionItem->price->id,
             'quantity' => $stripeSubscriptionItem->quantity,
+            'meter_event_name' => $meterEventName,
         ])->save();
 
         $stripeSubscription = $this->subscription->asStripeSubscription();
@@ -212,15 +223,23 @@ class SubscriptionItem extends Model
      */
     public function reportUsage($quantity = 1, $timestamp = null)
     {
-        // Get the price to determine the meter
-        $stripePrice = $this->subscription->owner->stripe()->prices->retrieve($this->stripe_price);
+        $eventName = $this->meter_event_name;
 
-        if (! isset($stripePrice->recurring->meter)) {
-            throw new \InvalidArgumentException('Price must have a meter to report usage. Legacy usage records are no longer supported.');
+        if (! $eventName) {
+            // Get the price to determine the meter
+            $stripePrice = $this->subscription->owner->stripe()->prices->retrieve($this->stripe_price);
+
+            if (! isset($stripePrice->recurring->meter)) {
+                throw new \InvalidArgumentException('Price must have a meter to report usage. Legacy usage records are no longer supported.');
+            }
+
+            // Get the meter to get the event name
+            $meter = $this->subscription->owner->stripe()->billing->meters->retrieve($stripePrice->recurring->meter);
+
+            $eventName = $meter->event_name;
+
+            $this->forceFill(['meter_event_name' => $eventName])->save();
         }
-
-        // Get the meter to get the event name
-        $meter = $this->subscription->owner->stripe()->billing->meters->retrieve($stripePrice->recurring->meter);
 
         // Convert timestamp to RFC 3339 format for v2 API
         if ($timestamp instanceof DateTimeInterface) {
@@ -232,7 +251,7 @@ class SubscriptionItem extends Model
         }
 
         return $this->subscription->owner->stripe()->v2->billing->meterEvents->create([
-            'event_name' => $meter->event_name,
+            'event_name' => $eventName,
             'payload' => [
                 'stripe_customer_id' => $this->subscription->owner->stripeId(),
                 'value' => (string) $quantity,

--- a/tests/Feature/MeteredBillingTest.php
+++ b/tests/Feature/MeteredBillingTest.php
@@ -24,6 +24,16 @@ class MeteredBillingTest extends FeatureTestCase
     /**
      * @var string
      */
+    protected static $meterEventName;
+
+    /**
+     * @var string
+     */
+    protected static $otherMeterEventName;
+
+    /**
+     * @var string
+     */
     protected static $meteredPrice;
 
     /**
@@ -51,9 +61,12 @@ class MeteredBillingTest extends FeatureTestCase
         // Create meters for the new billing system with unique event names
         $timestamp = time();
 
+        static::$meterEventName = 'api_request_'.$timestamp;
+        static::$otherMeterEventName = 'premium_api_request_'.$timestamp;
+
         static::$meterId = self::stripe()->billing->meters->create([
             'display_name' => 'API Requests',
-            'event_name' => 'api_request_'.$timestamp,
+            'event_name' => static::$meterEventName,
             'customer_mapping' => [
                 'event_payload_key' => 'stripe_customer_id',
                 'type' => 'by_id',
@@ -68,7 +81,7 @@ class MeteredBillingTest extends FeatureTestCase
 
         static::$otherMeterId = self::stripe()->billing->meters->create([
             'display_name' => 'Premium API Requests',
-            'event_name' => 'premium_api_request_'.$timestamp,
+            'event_name' => static::$otherMeterEventName,
             'customer_mapping' => [
                 'event_payload_key' => 'stripe_customer_id',
                 'type' => 'by_id',
@@ -124,6 +137,9 @@ class MeteredBillingTest extends FeatureTestCase
         $subscription = $user->newSubscription('main')
             ->meteredPrice(static::$meteredPrice)
             ->create('pm_card_visa');
+
+        $item = $subscription->items->first();
+        $this->assertSame(static::$meterEventName, $item->meter_event_name);
 
         // Test that meter events are created successfully with synchronous validation
         $event1 = $subscription->reportUsage(5);


### PR DESCRIPTION
## Summary
- allow storing meter event names for subscription items
- use stored meter event names when reporting usage
- add migration and factory support for new column
- test meter_event_name persistence